### PR TITLE
feat: improve web UI with filtering, pagination, and span details

### DIFF
--- a/src/server/web.rs
+++ b/src/server/web.rs
@@ -1,13 +1,15 @@
+use axum::response::sse::{Event, KeepAlive};
 use axum::{
     Router,
     extract::{Query, State},
-    http::{StatusCode, header},
-    response::{IntoResponse, Json, Sse},
+    http::{HeaderValue, StatusCode, header},
+    middleware::{self, Next},
+    response::{IntoResponse, Json, Response, Sse},
     routing::get,
 };
-use axum::response::sse::{Event, KeepAlive};
 use datafusion::prelude::SessionContext;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::convert::Infallible;
 use std::sync::Arc;
 use tokio::sync::broadcast;
@@ -27,6 +29,25 @@ pub struct WebState {
     pub session_ctx: Arc<SessionContext>,
 }
 
+/// CORS middleware that adds permissive headers for reverse proxy support.
+async fn cors_middleware(request: axum::http::Request<axum::body::Body>, next: Next) -> Response {
+    let mut response = next.run(request).await;
+    let headers = response.headers_mut();
+    headers.insert(
+        header::ACCESS_CONTROL_ALLOW_ORIGIN,
+        HeaderValue::from_static("*"),
+    );
+    headers.insert(
+        header::ACCESS_CONTROL_ALLOW_METHODS,
+        HeaderValue::from_static("GET, POST, OPTIONS"),
+    );
+    headers.insert(
+        header::ACCESS_CONTROL_ALLOW_HEADERS,
+        HeaderValue::from_static("Content-Type"),
+    );
+    response
+}
+
 pub fn router(state: WebState) -> Router {
     Router::new()
         // Static assets
@@ -41,6 +62,7 @@ pub fn router(state: WebState) -> Router {
         .route("/api/sql", get(api_sql))
         // Real-time updates
         .route("/api/events", get(sse_events))
+        .layer(middleware::from_fn(cors_middleware))
         .with_state(state)
 }
 
@@ -49,18 +71,27 @@ pub fn router(state: WebState) -> Router {
 // ---------------------------------------------------------------------------
 
 async fn index_html() -> impl IntoResponse {
-    ([(header::CONTENT_TYPE, "text/html; charset=utf-8")], INDEX_HTML)
+    (
+        [(header::CONTENT_TYPE, "text/html; charset=utf-8")],
+        INDEX_HTML,
+    )
 }
 
 async fn app_js() -> impl IntoResponse {
     (
-        [(header::CONTENT_TYPE, "application/javascript; charset=utf-8")],
+        [(
+            header::CONTENT_TYPE,
+            "application/javascript; charset=utf-8",
+        )],
         APP_JS,
     )
 }
 
 async fn style_css() -> impl IntoResponse {
-    ([(header::CONTENT_TYPE, "text/css; charset=utf-8")], STYLE_CSS)
+    (
+        [(header::CONTENT_TYPE, "text/css; charset=utf-8")],
+        STYLE_CSS,
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -96,7 +127,9 @@ struct SpanNodeJson {
     duration_ns: u64,
     start_ns: u64,
     status_code: i32,
+    status_message: String,
     depth: usize,
+    attributes: HashMap<String, String>,
 }
 
 #[derive(Serialize)]
@@ -115,6 +148,25 @@ struct MetricJson {
     unit: String,
     display_value: String,
     data_point_count: usize,
+}
+
+#[derive(Deserialize)]
+struct WebTraceParams {
+    service: Option<String>,
+    limit: Option<usize>,
+}
+
+#[derive(Deserialize)]
+struct WebLogParams {
+    service: Option<String>,
+    severity: Option<String>,
+    limit: Option<usize>,
+}
+
+#[derive(Deserialize)]
+struct WebMetricParams {
+    service: Option<String>,
+    limit: Option<usize>,
 }
 
 #[derive(Deserialize)]
@@ -171,11 +223,30 @@ async fn api_status(State(state): State<WebState>) -> Json<StatusResponse> {
     })
 }
 
-async fn api_traces(State(state): State<WebState>) -> Json<Vec<TraceGroupJson>> {
+async fn api_traces(
+    State(state): State<WebState>,
+    Query(params): Query<WebTraceParams>,
+) -> Json<Vec<TraceGroupJson>> {
     let store = state.store.read().await;
     let all_spans = app::flatten_traces(&store.traces);
-    let groups = app::group_traces(all_spans);
+    let mut groups = app::group_traces(all_spans);
     drop(store);
+
+    // Filter by service name
+    if let Some(ref service) = params.service
+        && !service.is_empty()
+    {
+        groups.retain(|g| {
+            g.service_name
+                .to_lowercase()
+                .contains(&service.to_lowercase())
+        });
+    }
+
+    // Apply limit
+    if let Some(limit) = params.limit {
+        groups.truncate(limit);
+    }
 
     let json_groups: Vec<TraceGroupJson> = groups
         .into_iter()
@@ -183,16 +254,39 @@ async fn api_traces(State(state): State<WebState>) -> Json<Vec<TraceGroupJson>> 
             let tree_nodes = app::build_span_tree(&g.spans);
             let spans: Vec<SpanNodeJson> = tree_nodes
                 .into_iter()
-                .map(|node| SpanNodeJson {
-                    span_id: hex::encode(&node.span.span_id),
-                    parent_span_id: hex::encode(&node.span.parent_span_id),
-                    service_name: node.span.service_name.clone(),
-                    span_name: node.span.span_name.clone(),
-                    duration: format_duration(node.span.duration_ns),
-                    duration_ns: node.span.duration_ns,
-                    start_ns: node.span.time_nano,
-                    status_code: node.span.status_code,
-                    depth: node.depth,
+                .map(|node| {
+                    let attrs: HashMap<String, String> = node
+                        .span
+                        .attributes
+                        .iter()
+                        .map(|kv| {
+                            let val = kv
+                                .value
+                                .as_ref()
+                                .and_then(|v| v.value.as_ref())
+                                .map(|v| match v {
+                                    crate::otel::common::v1::any_value::Value::StringValue(s) => {
+                                        s.clone()
+                                    }
+                                    other => format!("{other:?}"),
+                                })
+                                .unwrap_or_default();
+                            (kv.key.clone(), val)
+                        })
+                        .collect();
+                    SpanNodeJson {
+                        span_id: hex::encode(&node.span.span_id),
+                        parent_span_id: hex::encode(&node.span.parent_span_id),
+                        service_name: node.span.service_name.clone(),
+                        span_name: node.span.span_name.clone(),
+                        duration: format_duration(node.span.duration_ns),
+                        duration_ns: node.span.duration_ns,
+                        start_ns: node.span.time_nano,
+                        status_code: node.span.status_code,
+                        status_message: node.span.status_message.clone(),
+                        depth: node.depth,
+                        attributes: attrs,
+                    }
                 })
                 .collect();
             TraceGroupJson {
@@ -210,10 +304,37 @@ async fn api_traces(State(state): State<WebState>) -> Json<Vec<TraceGroupJson>> 
     Json(json_groups)
 }
 
-async fn api_logs(State(state): State<WebState>) -> Json<Vec<LogRowJson>> {
+async fn api_logs(
+    State(state): State<WebState>,
+    Query(params): Query<WebLogParams>,
+) -> Json<Vec<LogRowJson>> {
     let store = state.store.read().await;
-    let log_rows = app::flatten_logs(&store.logs);
+    let mut log_rows = app::flatten_logs(&store.logs);
     drop(store);
+
+    // Filter by service name
+    if let Some(ref service) = params.service
+        && !service.is_empty()
+    {
+        log_rows.retain(|l| {
+            l.service_name
+                .to_lowercase()
+                .contains(&service.to_lowercase())
+        });
+    }
+
+    // Filter by severity
+    if let Some(ref severity) = params.severity
+        && !severity.is_empty()
+    {
+        let sev_upper = severity.to_uppercase();
+        log_rows.retain(|l| l.severity_text.to_uppercase() == sev_upper);
+    }
+
+    // Apply limit
+    if let Some(limit) = params.limit {
+        log_rows.truncate(limit);
+    }
 
     let json_logs: Vec<LogRowJson> = log_rows
         .into_iter()
@@ -228,10 +349,29 @@ async fn api_logs(State(state): State<WebState>) -> Json<Vec<LogRowJson>> {
     Json(json_logs)
 }
 
-async fn api_metrics(State(state): State<WebState>) -> Json<Vec<MetricJson>> {
+async fn api_metrics(
+    State(state): State<WebState>,
+    Query(params): Query<WebMetricParams>,
+) -> Json<Vec<MetricJson>> {
     let store = state.store.read().await;
-    let aggregated = app::aggregate_metrics(&store.metrics);
+    let mut aggregated = app::aggregate_metrics(&store.metrics);
     drop(store);
+
+    // Filter by service name
+    if let Some(ref service) = params.service
+        && !service.is_empty()
+    {
+        aggregated.retain(|m| {
+            m.service_name
+                .to_lowercase()
+                .contains(&service.to_lowercase())
+        });
+    }
+
+    // Apply limit
+    if let Some(limit) = params.limit {
+        aggregated.truncate(limit);
+    }
 
     let json_metrics: Vec<MetricJson> = aggregated
         .into_iter()
@@ -312,10 +452,9 @@ mod tests {
     async fn make_test_state() -> WebState {
         let (store, _rx) = crate::store::Store::new_shared(100, 100, 100);
         let event_tx = store.read().await.event_tx.clone();
-        let session_ctx =
-            crate::query::datafusion_ctx::create_context(store.clone())
-                .await
-                .unwrap();
+        let session_ctx = crate::query::datafusion_ctx::create_context(store.clone())
+            .await
+            .unwrap();
         WebState {
             store,
             event_tx,
@@ -332,7 +471,12 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
-        let ct = resp.headers().get(header::CONTENT_TYPE).unwrap().to_str().unwrap();
+        let ct = resp
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .unwrap()
+            .to_str()
+            .unwrap();
         assert!(ct.contains("text/html"));
     }
 
@@ -345,7 +489,12 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
-        let ct = resp.headers().get(header::CONTENT_TYPE).unwrap().to_str().unwrap();
+        let ct = resp
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .unwrap()
+            .to_str()
+            .unwrap();
         assert!(ct.contains("javascript"));
     }
 
@@ -358,7 +507,12 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
-        let ct = resp.headers().get(header::CONTENT_TYPE).unwrap().to_str().unwrap();
+        let ct = resp
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .unwrap()
+            .to_str()
+            .unwrap();
         assert!(ct.contains("text/css"));
     }
 

--- a/src/server/web_assets/app.js
+++ b/src/server/web_assets/app.js
@@ -68,6 +68,28 @@ function statusClass(code) {
     return 'status-unset';
 }
 
+function statusText(code) {
+    if (code === 1) return 'OK';
+    if (code === 2) return 'ERROR';
+    return 'UNSET';
+}
+
+function statusBadgeClass(code) {
+    if (code === 1) return 'ok';
+    if (code === 2) return 'error';
+    return 'unset';
+}
+
+// ---------------------------------------------------------------------------
+// Pagination state
+// ---------------------------------------------------------------------------
+var DEFAULT_LIMIT = 200;
+var LOAD_MORE_INCREMENT = 200;
+
+var logsLimit = DEFAULT_LIMIT;
+var tracesLimit = DEFAULT_LIMIT;
+var metricsLimit = DEFAULT_LIMIT;
+
 // ---------------------------------------------------------------------------
 // SSE connection for real-time updates
 // ---------------------------------------------------------------------------
@@ -98,6 +120,19 @@ function connectSSE() {
 }
 
 // ---------------------------------------------------------------------------
+// Build query string from filter params
+// ---------------------------------------------------------------------------
+function buildQueryString(params) {
+    var parts = [];
+    for (var key in params) {
+        if (params[key] !== undefined && params[key] !== null && params[key] !== '') {
+            parts.push(encodeURIComponent(key) + '=' + encodeURIComponent(params[key]));
+        }
+    }
+    return parts.length > 0 ? '?' + parts.join('&') : '';
+}
+
+// ---------------------------------------------------------------------------
 // Fetch and render: Status
 // ---------------------------------------------------------------------------
 function fetchStatus() {
@@ -113,15 +148,23 @@ function fetchStatus() {
 // Fetch and render: Logs
 // ---------------------------------------------------------------------------
 function fetchLogs() {
-    fetch('/api/logs').then(function(r) { return r.json(); }).then(function(logs) {
+    var service = document.getElementById('logs-filter-service').value.trim();
+    var severity = document.getElementById('logs-filter-severity').value;
+    var qs = buildQueryString({ service: service, severity: severity, limit: logsLimit });
+
+    fetch('/api/logs' + qs).then(function(r) { return r.json(); }).then(function(logs) {
         var tbody = document.querySelector('#logs-table tbody');
         var empty = document.getElementById('logs-empty');
+        var loadMore = document.getElementById('logs-load-more');
         if (!logs || logs.length === 0) {
             tbody.innerHTML = '';
             empty.style.display = 'block';
+            loadMore.style.display = 'none';
             return;
         }
         empty.style.display = 'none';
+        // Show load more if we hit the limit
+        loadMore.style.display = logs.length >= logsLimit ? 'block' : 'none';
         // Show newest first
         var rows = logs.slice().reverse();
         tbody.innerHTML = rows.map(function(log) {
@@ -141,7 +184,10 @@ function fetchLogs() {
 var traceGroups = [];
 
 function fetchTraces() {
-    fetch('/api/traces').then(function(r) { return r.json(); }).then(function(groups) {
+    var service = document.getElementById('traces-filter-service').value.trim();
+    var qs = buildQueryString({ service: service, limit: tracesLimit });
+
+    fetch('/api/traces' + qs).then(function(r) { return r.json(); }).then(function(groups) {
         traceGroups = groups || [];
         renderTraceList();
     }).catch(function() {});
@@ -150,12 +196,15 @@ function fetchTraces() {
 function renderTraceList() {
     var tbody = document.querySelector('#traces-table tbody');
     var empty = document.getElementById('traces-empty');
+    var loadMore = document.getElementById('traces-load-more');
     if (!traceGroups || traceGroups.length === 0) {
         tbody.innerHTML = '';
         empty.style.display = 'block';
+        loadMore.style.display = 'none';
         return;
     }
     empty.style.display = 'none';
+    loadMore.style.display = traceGroups.length >= tracesLimit ? 'block' : 'none';
     // Show newest first
     var groups = traceGroups.slice().reverse();
     tbody.innerHTML = groups.map(function(g, i) {
@@ -189,6 +238,11 @@ function showTraceDetail(idx) {
     document.getElementById('trace-detail-title').textContent =
         g.root_span_name + ' (' + g.span_count + ' spans, ' + g.duration + ')';
 
+    // Hide span detail panel
+    var spanDetail = document.getElementById('span-detail');
+    spanDetail.classList.remove('active');
+    spanDetail.innerHTML = '';
+
     // Build waterfall
     var spans = g.spans || [];
     if (spans.length === 0) return;
@@ -203,7 +257,7 @@ function showTraceDetail(idx) {
     if (totalRange === 0) totalRange = 1;
 
     var tbody = document.querySelector('#waterfall-table tbody');
-    tbody.innerHTML = spans.map(function(s) {
+    tbody.innerHTML = spans.map(function(s, i) {
         var indent = '';
         for (var d = 0; d < s.depth; d++) {
             indent += d === s.depth - 1 ? '<span class="tree-indent">\u251c\u2500 </span>' : '<span class="tree-indent">\u2502  </span>';
@@ -212,34 +266,91 @@ function showTraceDetail(idx) {
         var widthPct = Math.max(0.5, (s.duration_ns / totalRange * 100)).toFixed(2);
         var color = serviceColor(s.service_name);
         var statusCls = statusClass(s.status_code);
-        return '<tr>' +
+        var badgeCls = statusBadgeClass(s.status_code);
+        var sText = statusText(s.status_code);
+        return '<tr class="span-row" data-span-idx="' + i + '">' +
             '<td class="span-name">' + indent + '<span class="' + statusCls + '">' + escapeHtml(s.span_name) + '</span></td>' +
+            '<td style="font-size:11px;color:' + color + '">' + escapeHtml(s.service_name) + '</td>' +
             '<td class="span-bar-cell"><div class="span-bar-container">' +
             '<div class="span-bar" style="left:' + leftPct + '%;width:' + widthPct + '%;background:' + color + '" title="' + escapeHtml(s.service_name) + ': ' + escapeHtml(s.span_name) + '"></div>' +
             '</div></td>' +
             '<td class="span-duration">' + escapeHtml(s.duration) + '</td>' +
+            '<td><span class="status-badge ' + badgeCls + '">' + sText + '</span></td>' +
             '</tr>';
     }).join('');
+
+    // Click handlers for span rows
+    tbody.querySelectorAll('.span-row').forEach(function(row) {
+        row.addEventListener('click', function() {
+            // Remove previous selection
+            tbody.querySelectorAll('.span-row').forEach(function(r) { r.classList.remove('selected'); });
+            row.classList.add('selected');
+            var spanIdx = parseInt(row.getAttribute('data-span-idx'));
+            showSpanDetail(spans[spanIdx]);
+        });
+    });
+}
+
+function showSpanDetail(span) {
+    if (!span) return;
+    var panel = document.getElementById('span-detail');
+    panel.classList.add('active');
+
+    var statusCls = statusClass(span.status_code);
+    var sText = statusText(span.status_code);
+
+    var html = '<h4>Span Detail</h4>';
+    html += '<div class="detail-row"><span class="detail-key">Span Name</span><span class="detail-value">' + escapeHtml(span.span_name) + '</span></div>';
+    html += '<div class="detail-row"><span class="detail-key">Service</span><span class="detail-value">' + escapeHtml(span.service_name) + '</span></div>';
+    html += '<div class="detail-row"><span class="detail-key">Span ID</span><span class="detail-value" style="font-family:monospace;font-size:11px">' + escapeHtml(span.span_id) + '</span></div>';
+    if (span.parent_span_id && span.parent_span_id !== '0000000000000000') {
+        html += '<div class="detail-row"><span class="detail-key">Parent Span ID</span><span class="detail-value" style="font-family:monospace;font-size:11px">' + escapeHtml(span.parent_span_id) + '</span></div>';
+    }
+    html += '<div class="detail-row"><span class="detail-key">Duration</span><span class="detail-value">' + escapeHtml(span.duration) + '</span></div>';
+    html += '<div class="detail-row"><span class="detail-key">Status</span><span class="detail-value ' + statusCls + '">' + sText + '</span></div>';
+    if (span.status_message) {
+        html += '<div class="detail-row"><span class="detail-key">Status Message</span><span class="detail-value">' + escapeHtml(span.status_message) + '</span></div>';
+    }
+
+    // Attributes
+    var attrs = span.attributes || {};
+    var attrKeys = Object.keys(attrs);
+    if (attrKeys.length > 0) {
+        html += '<div class="attrs-section"><h4>Attributes</h4>';
+        attrKeys.sort().forEach(function(key) {
+            html += '<div class="detail-row"><span class="detail-key">' + escapeHtml(key) + '</span><span class="detail-value">' + escapeHtml(String(attrs[key])) + '</span></div>';
+        });
+        html += '</div>';
+    }
+
+    panel.innerHTML = html;
 }
 
 document.getElementById('trace-back').addEventListener('click', function() {
     document.getElementById('trace-detail').classList.remove('active');
     document.querySelector('.trace-list').style.display = 'block';
+    document.getElementById('span-detail').classList.remove('active');
 });
 
 // ---------------------------------------------------------------------------
 // Fetch and render: Metrics
 // ---------------------------------------------------------------------------
 function fetchMetrics() {
-    fetch('/api/metrics').then(function(r) { return r.json(); }).then(function(metrics) {
+    var service = document.getElementById('metrics-filter-service').value.trim();
+    var qs = buildQueryString({ service: service, limit: metricsLimit });
+
+    fetch('/api/metrics' + qs).then(function(r) { return r.json(); }).then(function(metrics) {
         var tbody = document.querySelector('#metrics-table tbody');
         var empty = document.getElementById('metrics-empty');
+        var loadMore = document.getElementById('metrics-load-more');
         if (!metrics || metrics.length === 0) {
             tbody.innerHTML = '';
             empty.style.display = 'block';
+            loadMore.style.display = 'none';
             return;
         }
         empty.style.display = 'none';
+        loadMore.style.display = metrics.length >= metricsLimit ? 'block' : 'none';
         tbody.innerHTML = metrics.map(function(m) {
             return '<tr>' +
                 '<td>' + escapeHtml(m.metric_name) + '</td>' +
@@ -252,6 +363,57 @@ function fetchMetrics() {
         }).join('');
     }).catch(function() {});
 }
+
+// ---------------------------------------------------------------------------
+// Filter apply handlers
+// ---------------------------------------------------------------------------
+document.getElementById('logs-filter-apply').addEventListener('click', function() {
+    logsLimit = DEFAULT_LIMIT;
+    fetchLogs();
+});
+
+document.getElementById('traces-filter-apply').addEventListener('click', function() {
+    tracesLimit = DEFAULT_LIMIT;
+    fetchTraces();
+});
+
+document.getElementById('metrics-filter-apply').addEventListener('click', function() {
+    metricsLimit = DEFAULT_LIMIT;
+    fetchMetrics();
+});
+
+// Also apply on Enter key in filter inputs
+document.getElementById('logs-filter-service').addEventListener('keydown', function(e) {
+    if (e.key === 'Enter') { logsLimit = DEFAULT_LIMIT; fetchLogs(); }
+});
+document.getElementById('traces-filter-service').addEventListener('keydown', function(e) {
+    if (e.key === 'Enter') { tracesLimit = DEFAULT_LIMIT; fetchTraces(); }
+});
+document.getElementById('metrics-filter-service').addEventListener('keydown', function(e) {
+    if (e.key === 'Enter') { metricsLimit = DEFAULT_LIMIT; fetchMetrics(); }
+});
+document.getElementById('logs-filter-severity').addEventListener('change', function() {
+    logsLimit = DEFAULT_LIMIT;
+    fetchLogs();
+});
+
+// ---------------------------------------------------------------------------
+// Load more handlers
+// ---------------------------------------------------------------------------
+document.getElementById('logs-load-more').addEventListener('click', function() {
+    logsLimit += LOAD_MORE_INCREMENT;
+    fetchLogs();
+});
+
+document.getElementById('traces-load-more').addEventListener('click', function() {
+    tracesLimit += LOAD_MORE_INCREMENT;
+    fetchTraces();
+});
+
+document.getElementById('metrics-load-more').addEventListener('click', function() {
+    metricsLimit += LOAD_MORE_INCREMENT;
+    fetchMetrics();
+});
 
 // ---------------------------------------------------------------------------
 // SQL query execution

--- a/src/server/web_assets/index.html
+++ b/src/server/web_assets/index.html
@@ -26,23 +26,42 @@
 
     <main>
         <div id="logs-tab" class="tab-content active">
+            <div class="filter-bar">
+                <input type="text" id="logs-filter-service" placeholder="Filter service..." class="filter-input">
+                <select id="logs-filter-severity" class="filter-input">
+                    <option value="">All severities</option>
+                    <option value="TRACE">TRACE</option>
+                    <option value="DEBUG">DEBUG</option>
+                    <option value="INFO">INFO</option>
+                    <option value="WARN">WARN</option>
+                    <option value="ERROR">ERROR</option>
+                    <option value="FATAL">FATAL</option>
+                </select>
+                <button class="filter-btn" id="logs-filter-apply">Apply</button>
+            </div>
             <div class="table-container">
                 <table id="logs-table">
                     <thead><tr><th>Time</th><th>Service</th><th>Severity</th><th>Body</th></tr></thead>
                     <tbody></tbody>
                 </table>
                 <div class="empty-state" id="logs-empty">No logs received yet</div>
+                <button class="load-more-btn" id="logs-load-more" style="display:none">Load more</button>
             </div>
         </div>
 
         <div id="traces-tab" class="tab-content">
             <div class="trace-list">
+                <div class="filter-bar">
+                    <input type="text" id="traces-filter-service" placeholder="Filter service..." class="filter-input">
+                    <button class="filter-btn" id="traces-filter-apply">Apply</button>
+                </div>
                 <div class="table-container">
                     <table id="traces-table">
                         <thead><tr><th>Trace ID</th><th>Service</th><th>Root Span</th><th>Spans</th><th>Duration</th><th>Time</th></tr></thead>
                         <tbody></tbody>
                     </table>
                     <div class="empty-state" id="traces-empty">No traces received yet</div>
+                    <button class="load-more-btn" id="traces-load-more" style="display:none">Load more</button>
                 </div>
             </div>
             <div id="trace-detail">
@@ -52,20 +71,26 @@
                 </div>
                 <div class="table-container">
                     <table class="waterfall" id="waterfall-table">
-                        <thead><tr><th>Span</th><th>Timeline</th><th>Duration</th></tr></thead>
+                        <thead><tr><th>Span</th><th>Service</th><th>Timeline</th><th>Duration</th><th>Status</th></tr></thead>
                         <tbody></tbody>
                     </table>
                 </div>
+                <div id="span-detail" class="span-detail-panel"></div>
             </div>
         </div>
 
         <div id="metrics-tab" class="tab-content">
+            <div class="filter-bar">
+                <input type="text" id="metrics-filter-service" placeholder="Filter service..." class="filter-input">
+                <button class="filter-btn" id="metrics-filter-apply">Apply</button>
+            </div>
             <div class="table-container">
                 <table id="metrics-table">
                     <thead><tr><th>Metric</th><th>Service</th><th>Type</th><th>Value</th><th>Unit</th><th>Data Points</th></tr></thead>
                     <tbody></tbody>
                 </table>
                 <div class="empty-state" id="metrics-empty">No metrics received yet</div>
+                <button class="load-more-btn" id="metrics-load-more" style="display:none">Load more</button>
             </div>
         </div>
 

--- a/src/server/web_assets/style.css
+++ b/src/server/web_assets/style.css
@@ -296,3 +296,119 @@ tbody tr:hover { background: var(--bg-lighter); }
 
 /* Span tree indentation */
 .tree-indent { color: var(--text-muted); }
+
+/* Filter bar */
+.filter-bar {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    padding: 8px 0;
+    margin-bottom: 4px;
+}
+
+.filter-input {
+    background: var(--bg-panel);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text);
+    font-family: inherit;
+    font-size: 12px;
+    padding: 4px 8px;
+    min-width: 140px;
+}
+
+.filter-input:focus { outline: none; border-color: var(--accent); }
+
+select.filter-input {
+    cursor: pointer;
+    appearance: auto;
+}
+
+.filter-btn {
+    padding: 4px 12px;
+    background: var(--bg-lighter);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 12px;
+}
+
+.filter-btn:hover { border-color: var(--accent); color: var(--text-bright); }
+
+/* Load more button */
+.load-more-btn {
+    display: block;
+    width: 100%;
+    padding: 8px;
+    margin-top: 4px;
+    background: var(--bg-lighter);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 12px;
+    text-align: center;
+}
+
+.load-more-btn:hover { border-color: var(--accent); color: var(--text-bright); }
+
+/* Span detail panel */
+.span-detail-panel {
+    display: none;
+    margin-top: 12px;
+    padding: 12px;
+    background: var(--bg-lighter);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    font-size: 12px;
+}
+
+.span-detail-panel.active { display: block; }
+
+.span-detail-panel h4 {
+    color: var(--accent);
+    margin-bottom: 8px;
+    font-size: 13px;
+}
+
+.span-detail-panel .detail-row {
+    display: flex;
+    padding: 2px 0;
+}
+
+.span-detail-panel .detail-key {
+    color: var(--text-muted);
+    min-width: 140px;
+    flex-shrink: 0;
+}
+
+.span-detail-panel .detail-value {
+    color: var(--text-bright);
+    word-break: break-all;
+}
+
+.span-detail-panel .attrs-section {
+    margin-top: 8px;
+    border-top: 1px solid var(--border);
+    padding-top: 8px;
+}
+
+/* Status badges in waterfall */
+.status-badge {
+    font-size: 10px;
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-weight: 600;
+}
+
+.status-badge.ok { background: rgba(152, 195, 121, 0.2); color: var(--green); }
+.status-badge.error { background: rgba(224, 108, 117, 0.2); color: var(--red); }
+.status-badge.unset { color: var(--text-muted); }
+
+/* Waterfall span row clickable */
+.waterfall tbody tr { cursor: pointer; }
+.waterfall tbody tr:hover { background: var(--bg-lighter); }
+.waterfall tbody tr.selected { background: rgba(97, 175, 239, 0.1); }


### PR DESCRIPTION
## Summary
- Add filter controls (service name, severity) to web dashboard tabs
- Default limit of 200 items with load-more pagination buttons
- Enhanced waterfall view with span status badges, service name column, and click-to-expand detail panel showing span attributes
- CORS headers via Axum middleware for reverse proxy deployments

## Test plan
- [x] `cargo clippy` -- no new warnings
- [x] `cargo test --test integration_web` -- 5 tests pass
- [x] `cargo test --bin motel "web::tests"` -- 11 unit tests pass
- [x] Manual verification of web UI at localhost:4320

🤖 Generated with [Claude Code](https://claude.com/claude-code)